### PR TITLE
Players should update to this version to resolve the “server not resp…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>su.nightexpress.lootconomy</groupId>
     <artifactId>LootConomy</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.21.4-R0.1-SNAPSHOT</version>
+            <version>1.21.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/su/nightexpress/lootconomy/currency/CurrencySettings.java
+++ b/src/main/java/su/nightexpress/lootconomy/currency/CurrencySettings.java
@@ -19,7 +19,11 @@ import su.nightexpress.nightcore.util.bukkit.NightSound;
 import su.nightexpress.nightcore.util.random.Rnd;
 import su.nightexpress.nightcore.util.wrapper.UniParticle;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.TreeMap;
 
 public class CurrencySettings {
@@ -34,15 +38,18 @@ public class CurrencySettings {
 
     private final TreeMap<Integer, ItemStack> itemStyle;
 
+    // Single Random instance for deterministic splitting
+    private static final Random SPLIT_RANDOM = new Random();
+
     public CurrencySettings(
-        @NotNull String dropFormat,
-        @NotNull UniParticle groundEffect,
-        @NotNull NightSound pickupSound,
-        boolean roundToInt,
-        boolean directToBalance,
-        double dailyLimit,
-        @NotNull DeathPenalty deathPenalty,
-        @NotNull TreeMap<Integer, ItemStack> itemStyle
+            @NotNull String dropFormat,
+            @NotNull UniParticle groundEffect,
+            @NotNull NightSound pickupSound,
+            boolean roundToInt,
+            boolean directToBalance,
+            double dailyLimit,
+            @NotNull DeathPenalty deathPenalty,
+            @NotNull TreeMap<Integer, ItemStack> itemStyle
     ) {
         this.dropFormat = dropFormat;
         this.groundEffect = groundEffect;
@@ -51,7 +58,6 @@ public class CurrencySettings {
         this.directToBalance = directToBalance;
         this.dailyLimit = dailyLimit;
         this.deathPenalty = deathPenalty;
-
         this.itemStyle = itemStyle;
     }
 
@@ -65,76 +71,79 @@ public class CurrencySettings {
         ).read(config);
 
         boolean roundToInt = ConfigValue.create(path + ".Round_To_Int",
-            false,
-            "Sets whether or not dropped item amount will be rounded to a whole number (integer) instead of being decimal."
+                false,
+                "Sets whether dropped item amount will be rounded to a whole number instead of being decimal."
         ).read(config);
 
         boolean directToBalance = ConfigValue.create(path + ".Instant_Pickup",
-            false,
-            "Sets whether or not this currnecy will be directly added to player's balance when dropped."
+                false,
+                "Sets whether currency will be instantly added to a player's balance when dropped."
         ).read(config);
 
         double dailyLimit = ConfigValue.create(path + ".Daily_Limit",
-            -1D,
-            "Sets how much currency can be earned daily on per-player basis.",
-            "Limit resets at new day's midnight.",
-            "Set to '0' or '-1' to disable."
+                -1D,
+                "How much currency can be earned daily per player. Reset at midnight.",
+                "Set to '0' or '-1' to disable."
         ).read(config);
 
         UniParticle groundEffect = ConfigValue.create(path + ".Effects.Particle_On_Ground",
-            UniParticle.redstone(Color.YELLOW, 1f),
-            "Sets particle effect for the dropped currency item."
+                UniParticle.redstone(Color.YELLOW, 1f),
+                "Particle effect for the dropped currency item."
         ).read(config);
 
-        // Update
         if (config.contains(path + ".Effects.Pickup_Sound.Name")) {
             NightSound.read(config, path + ".Effects.Pickup_Sound");
         }
 
         NightSound pickupSound = ConfigValue.create(path + ".Effects.Pickup_Sound",
-            NightSound.of(Sound.BLOCK_NOTE_BLOCK_BELL),
-            "Sets sound effect for a player who pickups currency item."
+                NightSound.of(Sound.BLOCK_NOTE_BLOCK_BELL),
+                "Sound effect when a player picks up a currency item."
         ).read(config);
 
         DeathPenalty deathPenalty = DeathPenalty.read(config, path + ".Death_Penalty");
 
         TreeMap<Integer, ItemStack> itemStyle = ConfigValue.forTreeMap(path + ".Item_Style_By_Amount",
-            (string) -> NumberUtil.getInteger(string, 0),
-            (cfg, path2, key) -> cfg.getItem(path2 + "." + key),
-            (cfg, path2, map) -> map.forEach((amount, item) -> cfg.setItem(path2 + "." + amount, item)),
-            () -> {
-                TreeMap<Integer, ItemStack> map = new TreeMap<>();
-                if (currency.getInternalId().equalsIgnoreCase(CurrencyId.VAULT)) {
-                    map.put(0, getDefaultItem(Material.GOLD_NUGGET));
-                    map.put(100, getDefaultItem(Material.GOLD_INGOT));
-                    map.put(1000, getDefaultItem(Material.GOLD_BLOCK));
-                }
-                else {
-                    map.put(0, currency.getDefaultIcon());
-                }
-                return map;
-            },
-            "Here you can create different item styles depends on the dropped amount.",
-            "It will use item of the greatest amount less than or equal to the currency amount.",
-            Placeholders.URL_WIKI_ITEMS,
-            "[*] This setting is useless for some currencies (e.g. " + HookId.COINS_ENGINE + ")"
+                (string) -> NumberUtil.getInteger(string, 0),
+                (cfg, path2, key) -> cfg.getItem(path2 + "." + key),
+                (cfg, path2, map) -> map.forEach((amount, item) -> cfg.setItem(path2 + "." + amount, item)),
+                () -> {
+                    TreeMap<Integer, ItemStack> map = new TreeMap<>();
+                    if (currency.getInternalId().equalsIgnoreCase(CurrencyId.VAULT)) {
+                        map.put(0,    getDefaultItem(Material.GOLD_NUGGET));
+                        map.put(100,  getDefaultItem(Material.GOLD_INGOT));
+                        map.put(1000, getDefaultItem(Material.GOLD_BLOCK));
+                    } else {
+                        map.put(0, currency.getDefaultIcon());
+                    }
+                    return map;
+                },
+                "Create different item styles depending on the dropped amount.",
+                "Uses the item for the greatest key ≤ the currency amount.",
+                Placeholders.URL_WIKI_ITEMS,
+                "[*] Useless for some currencies (e.g. " + HookId.COINS_ENGINE + ")"
         ).read(config);
 
         itemStyle.values().removeIf(item -> item.getType().isAir());
-
         if (itemStyle.isEmpty()) {
             itemStyle.put(0, currency.getDefaultIcon());
         }
 
-        return new CurrencySettings(dropFormat, groundEffect, pickupSound, roundToInt, directToBalance, dailyLimit, deathPenalty, itemStyle);
+        return new CurrencySettings(
+                dropFormat,
+                groundEffect,
+                pickupSound,
+                roundToInt,
+                directToBalance,
+                dailyLimit,
+                deathPenalty,
+                itemStyle
+        );
     }
 
     @NotNull
     private static ItemStack getDefaultItem(@NotNull Material material) {
         ItemStack item = new ItemStack(material);
-        ItemUtil.editMeta(item, meta -> {
-            meta.addEnchant(Enchantment.UNBREAKING, 1, true);
-        });
+        ItemUtil.editMeta(item, meta -> meta.addEnchant(Enchantment.UNBREAKING, 1, true));
         return item;
     }
 
@@ -143,13 +152,66 @@ public class CurrencySettings {
         return currency.applyFormat(this.dropFormat, amount);
     }
 
+    /**
+     * Splits `fullAmount` (in the currency's smallest unit) into `parts` random portions.
+     * Always terminates in O(parts·log parts) time.
+     *
+     * @param currency   The Currency instance, used to apply fineValue() on each piece.
+     * @param fullAmount The total amount (e.g., in “cents”) to split.
+     * @param parts      Number of random pieces to generate (must be ≥ 1).
+     * @return A List of length `parts`, each a double ≥ 0, summing (after fineValue) ≈ fullAmount.
+     *         If fullAmount < parts, some pieces may be zero; each is wrapped through currency.fineValue().
+     */
+    @NotNull
+    public List<Double> cutRandom(@NotNull Currency currency, double fullAmount, int parts) {
+        List<Double> result = new ArrayList<>();
+        if (parts <= 0) {
+            return result;
+        }
+
+        // If fullAmount is smaller than parts, assign 1 unit to integer(floor(fullAmount)) pieces, rest zero.
+        if (fullAmount < parts) {
+            int integerPortion = (int) Math.floor(fullAmount);
+            for (int i = 0; i < integerPortion; i++) {
+                result.add(currency.fineValue(1.0));
+            }
+            for (int i = integerPortion; i < parts; i++) {
+                result.add(0.0);
+            }
+            return result;
+        }
+
+        // Generate (parts - 1) random cut points in [0, fullAmount]
+        List<Double> cuts = new ArrayList<>(parts + 1);
+        cuts.add(0.0);
+        for (int i = 0; i < parts - 1; i++) {
+            cuts.add(SPLIT_RANDOM.nextDouble() * fullAmount);
+        }
+        cuts.add(fullAmount);
+
+        Collections.sort(cuts);
+
+        // Differences between consecutive cuts form each piece
+        for (int i = 1; i < cuts.size(); i++) {
+            double portion = cuts.get(i) - cuts.get(i - 1);
+            if (this.isRoundToInt()) {
+                portion = Math.ceil(portion);
+            }
+            result.add(currency.fineValue(portion));
+        }
+        return result;
+    }
+
+    /**
+     * Deprecated: Use cutRandom(Currency, double, int) instead.
+     * Picks one random “cut” in [0, fullAmount], applies rounding if enabled, then fineValue().
+     */
+    @Deprecated
     public double cutRandom(@NotNull Currency currency, double fullAmount) {
         double cut = Rnd.getDouble(fullAmount);
-
         if (this.isRoundToInt()) {
             cut = Math.ceil(cut);
         }
-
         return currency.fineValue(cut);
     }
 
@@ -189,6 +251,9 @@ public class CurrencySettings {
         return deathPenalty;
     }
 
+    /**
+     * Returns the appropriate ItemStack icon for a given amount, based on configured thresholds.
+     */
     @NotNull
     public ItemStack getIcon(double amount) {
         Map.Entry<Integer, ItemStack> entry = this.itemStyle.floorEntry((int) Math.abs(amount));

--- a/src/main/java/su/nightexpress/lootconomy/loot/handler/LootHandlers.java
+++ b/src/main/java/su/nightexpress/lootconomy/loot/handler/LootHandlers.java
@@ -7,8 +7,13 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.Ageable;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.damage.DamageType;
-import org.bukkit.entity.*;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.EntityType;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.event.player.PlayerHarvestBlockEvent;
@@ -24,11 +29,59 @@ import su.nightexpress.lootconomy.money.MoneyUtils;
 import su.nightexpress.nightcore.util.LocationUtil;
 import su.nightexpress.nightcore.util.blocktracker.PlayerBlockTracker;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 @SuppressWarnings("UnstableApiUsage")
 public class LootHandlers {
 
+    /**
+     * Core helper that retrieves loot from the provider and hands each ItemStack
+     * to the supplied consumer. Logs any null / AIR items or exceptions.
+     */
+    private static <O> void dropLoot(@NotNull LootConomyPlugin plugin,
+                                     @NotNull Player player,
+                                     @NotNull O object,
+                                     @NotNull LootProvider<O> provider,
+                                     @NotNull Consumer<ItemStack> consumer) {
+        if (provider == null) {
+            plugin.getLogger().severe("[Loot] LootProvider was null for object: " + object);
+            return;
+        }
+
+        List<ItemStack> lootList;
+        try {
+            lootList = provider.createLoot(plugin, player, object);
+        } catch (Exception e) {
+            plugin.getLogger().severe("[Loot] Exception in LootProvider.createLoot for: "
+                    + object + " | " + e.getMessage());
+            e.printStackTrace();
+            return;
+        }
+
+        if (lootList == null) {
+            plugin.getLogger().warning("[Loot] LootProvider.createLoot returned null for: " + object);
+            return;
+        }
+
+        for (ItemStack item : lootList) {
+            if (item != null && item.getType() != Material.AIR) {
+                try {
+                    consumer.accept(item);
+                } catch (Exception e) {
+                    plugin.getLogger().severe("[Loot] Exception while consuming item for: "
+                            + object + " | " + e.getMessage());
+                    e.printStackTrace();
+                }
+            } else {
+                plugin.getLogger().warning("[Loot] Generated null or AIR item for: " + object);
+            }
+        }
+    }
+
+    /**
+     * Drops loot at a centered location around the passed-in location.
+     */
     private static <O> void dropLoot(@NotNull LootConomyPlugin plugin,
                                      @NotNull Player player,
                                      @NotNull O object,
@@ -36,32 +89,32 @@ public class LootHandlers {
                                      @NotNull Location location) {
         Location center = LocationUtil.setCenter3D(location.clone());
         dropLoot(plugin, player, object, provider, itemStack -> {
-            player.getWorld().dropItem(center, itemStack);
+            if (itemStack != null && itemStack.getType() != Material.AIR) {
+                player.getWorld().dropItem(center, itemStack);
+            }
         });
     }
 
-    private static <O> void dropLoot(@NotNull LootConomyPlugin plugin,
-                                     @NotNull Player player,
-                                     @NotNull O object,
-                                     @NotNull LootProvider<O> provider,
-                                     @NotNull Consumer<ItemStack> consumer) {
-        provider.createLoot(plugin, player, object).forEach(consumer);
-    }
-
+    /**
+     * Handler for when a block is broken.
+     */
     public static final LootHandler<BlockBreakEvent, Material> BLOCK_BREAK = (plugin, event, provider) -> {
         Block block = event.getBlock();
         BlockData blockData = block.getBlockData();
         Material blockType = block.getType();
-        boolean isTall = blockType == Material.BAMBOO || blockType == Material.SUGAR_CANE;
+        boolean isTall = (blockType == Material.BAMBOO || blockType == Material.SUGAR_CANE);
 
-        // Do not give money for ungrowth plants.
         if (!isTall && blockData instanceof Ageable age) {
-            if (age.getAge() < age.getMaximumAge()) return false;
+            if (age.getAge() < age.getMaximumAge()) {
+                // Not fully grown → skip
+                return false;
+            }
         }
 
         Player player = event.getPlayer();
         ItemStack tool = player.getInventory().getItemInMainHand();
         int blockHeight = isTall ? (blockType == Material.BAMBOO ? 16 : 4) : 1;
+
         for (int currentHeight = 0; currentHeight < blockHeight; currentHeight++) {
             if (currentHeight > 0) {
                 block = block.getRelative(BlockFace.UP);
@@ -69,23 +122,33 @@ public class LootHandlers {
             }
 
             if (PlayerBlockTracker.isTracked(block)) {
+                // Already processed by another plugin/tracker → skip
                 continue;
             }
 
-            BlockBreakEvent event2 = new BlockBreakEvent(block, player);
-            Location center = LocationUtil.setCenter3D(event2.getBlock().getLocation());
+            // Simulate a sub-block break for multi-block crops/trees
+            Location center = LocationUtil.setCenter3D(block.getLocation());
 
             dropLoot(plugin, player, blockType, provider, itemStack -> {
-                if (ExcellentEnchantsHook.hasTelekinesis(tool)) {
-                    plugin.getMoneyManager().pickupMoney(player, itemStack);
+                if (itemStack == null || itemStack.getType() == Material.AIR) {
+                    plugin.getLogger().warning("[Loot][BLOCK_BREAK] Null/AIR for block type: " + blockType);
                     return;
                 }
-                player.getWorld().dropItem(center, itemStack);
+
+                if (ExcellentEnchantsHook.hasTelekinesis(tool)) {
+                    plugin.getMoneyManager().pickupMoney(player, itemStack);
+                } else {
+                    player.getWorld().dropItem(center, itemStack);
+                }
             });
         }
+
         return true;
     };
 
+    /**
+     * Handler for when a block is harvested (e.g., crops).
+     */
     public static final LootHandler<PlayerHarvestBlockEvent, Material> BLOCK_HARVEST = (plugin, event, provider) -> {
         Block block = event.getHarvestedBlock();
         if (PlayerBlockTracker.isTracked(block)) {
@@ -93,80 +156,158 @@ public class LootHandlers {
         }
 
         Player player = event.getPlayer();
-        //dropLoot(plugin, player, block.getType(), provider, block.getLocation());
         dropLoot(plugin, player, block.getType(), provider, itemStack -> {
+            if (itemStack == null || itemStack.getType() == Material.AIR) {
+                plugin.getLogger().warning("[Loot][BLOCK_HARVEST] Null/AIR for block type: " + block.getType());
+                return;
+            }
             event.getItemsHarvested().add(itemStack);
         });
+
         return true;
     };
 
+    /**
+     * Handler for when a living entity dies.
+     */
     public static final LootHandler<EntityDeathEvent, EntityType> ENTITY_KILL = (plugin, event, provider) -> {
         LivingEntity entity = event.getEntity();
+        if (entity == null) {
+            plugin.getLogger().warning("[Loot][ENTITY_KILL] EntityDeathEvent.getEntity() returned null");
+            return false;
+        }
 
-        // Do not drop money if not killed by a player.
         Player killer = entity.getKiller();
-        if (killer == null) return false;
+        if (killer == null) {
+            // Not killed by a player → skip
+            return false;
+        }
 
-        // Do not drop money if mob is handled by other plugin or if it was spawned by specific source.
-        if (MoneyUtils.isDevastated(entity)) return false;
-        if (!MoneyUtils.isVanillaMob(entity)) return false;
+        // --- Debug Logging ---
+        plugin.getLogger().info("[Loot][ENTITY_KILL] Processing death of " + entity.getType()
+                + " (killed by: " + killer.getName() + ")");
 
-        // Do not drop money for mobs inside non-living (boats, minecarts) vehicles.
+        // — Check if entity is “devastated” (custom tag or state) —
+        boolean isDevastated;
+        try {
+            isDevastated = MoneyUtils.isDevastated(entity);
+        } catch (Exception e) {
+            plugin.getLogger().severe("[Loot][ENTITY_KILL] isDevastated threw: " + e.getMessage());
+            e.printStackTrace();
+            return false;
+        }
+        if (isDevastated) {
+            plugin.getLogger().info("[Loot][ENTITY_KILL] Skipping " + entity.getType() + " because it is devastated");
+            return false;
+        }
+
+        // — Check if entity is vanilla (skip modded/custom mobs) —
+        boolean isVanilla;
+        try {
+            isVanilla = MoneyUtils.isVanillaMob(entity);
+        } catch (Exception e) {
+            plugin.getLogger().severe("[Loot][ENTITY_KILL] isVanillaMob threw: " + e.getMessage());
+            e.printStackTrace();
+            return false;
+        }
+        if (!isVanilla) {
+            plugin.getLogger().info("[Loot][ENTITY_KILL] Skipping " + entity.getType() + " because it is not a vanilla mob");
+            return false;
+        }
+
+        // — Check vehicle (skip if riding a non-living entity) —
         Entity vehicle = entity.getVehicle();
-        if (vehicle != null && !(vehicle instanceof LivingEntity)) return false;
+        if (vehicle != null && !(vehicle instanceof LivingEntity)) {
+            plugin.getLogger().info("[Loot][ENTITY_KILL] Skipping " + entity.getType()
+                    + " because vehicle is non-living: " + vehicle.getType());
+            return false;
+        }
 
-        // Do not drop money if mob died from cramming.
-        var lastCause = entity.getLastDamageCause();
-        if (lastCause != null && lastCause.getDamageSource().getDamageType() == DamageType.CRAMMING) return false;
+        // — Check last damage cause (skip if from cramming) —
+        EntityDamageEvent lastCause = entity.getLastDamageCause();
+        if (lastCause != null) {
+            var ds = lastCause.getDamageSource();
+            if (ds != null && ds.getDamageType() == DamageType.CRAMMING) {
+                plugin.getLogger().info("[Loot][ENTITY_KILL] Skipping " + entity.getType()
+                        + " due to cramming death");
+                return false;
+            }
+        }
 
-        dropLoot(plugin, killer, entity.getType(), provider, itemStack -> {
-            event.getDrops().add(itemStack);
-        });
+        // — Generate and add loot to event —
+        try {
+            plugin.getLogger().info("[Loot][ENTITY_KILL] Generating loot for " + entity.getType());
+            dropLoot(plugin, killer, entity.getType(), provider, itemStack -> {
+                if (itemStack == null || itemStack.getType() == Material.AIR) {
+                    plugin.getLogger().warning("[Loot][ENTITY_KILL] Null/AIR loot for " + entity.getType());
+                    return;
+                }
+
+                List<ItemStack> drops = event.getDrops();
+                if (drops == null) {
+                    plugin.getLogger().severe("[Loot][ENTITY_KILL] event.getDrops() returned null for "
+                            + entity.getType());
+                } else {
+                    drops.add(itemStack);
+                }
+            });
+        } catch (Exception e) {
+            plugin.getLogger().severe("[Loot][ENTITY_KILL] Exception while processing loot for "
+                    + entity.getType() + ": " + e.getMessage());
+            e.printStackTrace();
+            return false;
+        }
+
         return true;
     };
 
-//    public static final LootHandler<EntityDeathEvent, EntityType> ENTITY_SHOOT = (plugin, event, provider) -> {
-//        LivingEntity entity = event.getEntity();
-//        if (MoneyUtils.isDevastated(entity)) return false;
-//
-//        Player killer = entity.getKiller();
-//        if (killer == null) return false;
-//
-//        if (!(entity.getLastDamageCause() instanceof EntityDamageByEntityEvent ede)) return false;
-//        if (!(ede.getDamager() instanceof Projectile)) return false;
-//
-//        // Do not count MythicMobs here.
-//        if (Plugins.isLoaded(HookId.MYTHIC_MOBS) && MythicMobsHook.isMythicMob(entity)) return false;
-//
-//        dropLoot(plugin, killer, entity.getType(), provider, itemStack -> {
-//            event.getDrops().add(itemStack);
-//        });
-//        return true;
-//    };
-
+    /**
+     * Handler for when a player shears an entity (e.g., sheep).
+     */
     public static final LootHandler<PlayerShearEntityEvent, EntityType> ENTITY_SHEAR = (plugin, event, provider) -> {
         Player player = event.getPlayer();
         Entity entity = event.getEntity();
+        if (entity == null) {
+            plugin.getLogger().warning("[Loot][ENTITY_SHEAR] Event.getEntity() returned null");
+            return false;
+        }
 
         dropLoot(plugin, player, entity.getType(), provider, entity.getLocation());
         return true;
     };
 
+    /**
+     * Handler for when a player catches an item via fishing.
+     */
     public static final LootHandler<PlayerFishEvent, Material> ITEM_FISH = (plugin, event, provider) -> {
-        if (event.getState() != PlayerFishEvent.State.CAUGHT_FISH) return false;
+        if (event.getState() != PlayerFishEvent.State.CAUGHT_FISH) {
+            return false;
+        }
 
         Entity caught = event.getCaught();
-        if (!(caught instanceof Item item)) return false;
+        if (!(caught instanceof Item item)) {
+            return false;
+        }
 
         Player player = event.getPlayer();
         dropLoot(plugin, player, item.getItemStack().getType(), provider, itemStack -> {
+            if (itemStack == null || itemStack.getType() == Material.AIR) {
+                plugin.getLogger().warning("[Loot][ITEM_FISH] Null/AIR loot for caught item");
+                return;
+            }
+
             Location locHook = event.getHook().getLocation();
             Location locPlayer = player.getLocation();
+            Vector vec3d = new Vector(
+                    locPlayer.getX() - locHook.getX(),
+                    locPlayer.getY() - locHook.getY(),
+                    locPlayer.getZ() - locHook.getZ()
+            ).multiply(0.1D);
 
-            Vector vec3d = (new Vector(locPlayer.getX() - locHook.getX(), locPlayer.getY() - locHook.getY(), locPlayer.getZ() - locHook.getZ())).multiply(0.1D);
             Item drop = player.getWorld().dropItem(caught.getLocation(), itemStack);
             drop.setVelocity(drop.getVelocity().add(vec3d));
         });
+
         return true;
     };
 }


### PR DESCRIPTION
v2.2.1

FIXED:

Eliminated infinite‐loop hang when splitting currency amounts in MoneyManager.createLoot(...).

Replaced retry‐loop on cutRandom(...) with a single, multi‐split algorithm.

UPDATED:

CurrencySettings

Added cutRandom(Currency, double, int) to partition a total amount into N random pieces in one pass (O(N·log N) time).

Deprecated old single‐cut cutRandom(Currency, double) (retained for backward compatibility).

MoneyManager

Removed while (… cutRandom(…) …) loop.

Now calls new 3-arg cutRandom(...) once and iterates over returned splits.

Skips zero/negative splits instead of retrying, preventing server freeze.

LootHandlers

Added null‐checks around provider.createLoot(...), MoneyUtils.isDevastated(...), MoneyUtils.isVanillaMob(...), and event.getDrops().

Wrapped provider calls in try/catch; log warnings for null/AIR items and errors.

Ensured safe drop logic in ENTITY_KILL, BLOCK_BREAK, BLOCK_HARVEST, ENTITY_SHEAR, and ITEM_FISH handlers.

ADDED:

Logging when a LootProvider returns null or AIR item.

Safety checks to avoid NPEs if dropList or other internals are unexpectedly null.

REMOVED:

Any “retry until nonzero” logic in currency splitting.

Players should update to this version to resolve the “server not responding for 10 seconds” error.